### PR TITLE
Gets real Wordpress URL instead of host name

### DIFF
--- a/classes/SMTPMailingQueue.php
+++ b/classes/SMTPMailingQueue.php
@@ -125,8 +125,8 @@ class SMTPMailingQueue {
 	 */
 	public function getCronLink() {
 		$key = get_option('smtp_mailing_queue_advanced')['process_key'];
-		$protocol = $_SERVER['HTTPS'] == 'on' ? 'https' : 'http';
-		return $protocol.'://'.$_SERVER['HTTP_HOST'] . '?smqProcessQueue&key=' . $key;
+		$wpUrl = get_bloginfo("wpurl");
+		return $wpUrl . '?smqProcessQueue&key=' . $key;
 	}
 
 	/**


### PR DESCRIPTION
Hello,

I have Wordpress installed not in the root directory of the website. Your plugin didn't seem to be working using wp_cron: test emails remained in the queue.
I've applied a little fix.
Thanks for the useful plugin.
