### PR TITLE
inject global smtp queue instance through construct function

### DIFF
--- a/classes/SMTPMailingQueueAdvancedOptions.php
+++ b/classes/SMTPMailingQueueAdvancedOptions.php
@@ -18,8 +18,11 @@ class SMTPMailingQueueAdvancedOptions extends SMTPMailingQueueAdmin {
 	 */
 	private $tabName = 'advanced';
 
-	public function __construct() {
+	private $smtpMailingQueue;
+
+	public function __construct($smtpMailingQueue) {
 		parent::__construct();
+		$this->smtpMailingQueue = $smtpMailingQueue;
 		$this->init();
 	}
 
@@ -114,19 +117,18 @@ class SMTPMailingQueueAdvancedOptions extends SMTPMailingQueueAdmin {
 	 * @return array
 	 */
 	public function sanitize($input) {
-		global $smtpMailingQueue;
 		$sanitary_values = array();
 		if(isset( $input['queue_limit']))
 			$sanitary_values['queue_limit'] = intval($input['queue_limit']);
 		if(isset( $input['wpcron_interval'])) {
 			$sanitary_values['wpcron_interval'] = intval($input['wpcron_interval']);
-			$smtpMailingQueue->refreshWpCron();
+            $this->smtpMailingQueue->refreshWpCron();
 		}
 		if(isset($input['dont_use_wpcron'])) {
 			$sanitary_values['dont_use_wpcron'] = 'dont_use_wpcron';
 			wp_clear_scheduled_hook('smq_start_queue');
 		} else
-			$smtpMailingQueue->refreshWpCron();
+            $this->smtpMailingQueue->refreshWpCron();
 		if(isset($input['process_key']))
 			$sanitary_values['process_key'] = sanitize_text_field($input['process_key']);
 
@@ -185,13 +187,12 @@ class SMTPMailingQueueAdvancedOptions extends SMTPMailingQueueAdmin {
 	 * Prints checkbox field for selecting whether to use wp_cron or not
 	 */
 	public function dont_use_wpcron_callback() {
-		global $smtpMailingQueue;
 		printf(
 			'<input type="checkbox" name="%s[dont_use_wpcron]" id="dont_use_wpcron" value="dont_use_wpcron" %s> <label for="dont_use_wpcron">' . __('Use a real cronjob instead of wp_cron.', 'smtp-mailing-queue') . '</label>',
 			$this->optionName,
 			(isset($this->options['dont_use_wpcron']) && $this->options['dont_use_wpcron'] === 'dont_use_wpcron') ? 'checked' : ''
 		);
-		echo '<p class="description">' . sprintf(__('Call %s in cron to start processing queue.', 'smtp-mailing-queue'), '<strong>' . $smtpMailingQueue->getCronLink() . '</strong>') . '</p>';
+		echo '<p class="description">' . sprintf(__('Call %s in cron to start processing queue.', 'smtp-mailing-queue'), '<strong>' . $this->smtpMailingQueue->getCronLink() . '</strong>') . '</p>';
 	}
 
 	/**

--- a/classes/SMTPMailingQueueOptions.php
+++ b/classes/SMTPMailingQueueOptions.php
@@ -23,8 +23,11 @@ class SMTPMailingQueueOptions extends SMTPMailingQueueAdmin{
 	 */
 	private $optionsSanitized = false;
 
-	public function __construct() {
+	private $smtpMailingQueue;
+
+	public function __construct($smtpMailingQueue) {
 		parent::__construct();
+		$this->smtpMailingQueue = $smtpMailingQueue;
 		$this->init();
 	}
 
@@ -143,8 +146,6 @@ class SMTPMailingQueueOptions extends SMTPMailingQueueAdmin{
 	 * @return array
 	 */
 	public function sanitize($input) {
-		global $smtpMailingQueue;
-
 		// Fix for issue that options are sanitized twice when no db entry exists
 		// "It seems the data is passed through the sanitize function twice.[...]
 		// This should only happen when the option is not yet in the wp_options table."
@@ -171,7 +172,7 @@ class SMTPMailingQueueOptions extends SMTPMailingQueueAdmin{
 		if(isset($input['auth_username']))
 			$sanitary_values['auth_username'] = sanitize_text_field($input['auth_username']);
 		if(isset($input['auth_password']))
-			$sanitary_values['auth_password'] = $smtpMailingQueue->encrypt($input['auth_password']);
+			$sanitary_values['auth_password'] = $this->smtpMailingQueue->encrypt($input['auth_password']);
 
 		return $sanitary_values;
 	}
@@ -270,11 +271,10 @@ class SMTPMailingQueueOptions extends SMTPMailingQueueAdmin{
 	 * Prints field for SMTP authentication password
 	 */
 	public function auth_password_callback() {
-		global $smtpMailingQueue;
 		printf(
 			'<input class="regular-text" type="password" name="%s[auth_password]" id="auth_password" value="%s">',
 			$this->optionName,
-			isset($this->options['auth_password']) ? esc_attr($smtpMailingQueue->decrypt($this->options['auth_password'])) : ''
+			isset($this->options['auth_password']) ? esc_attr($this->smtpMailingQueue->decrypt($this->options['auth_password'])) : ''
 		);
 	}
 }

--- a/classes/SMTPMailingQueueTools.php
+++ b/classes/SMTPMailingQueueTools.php
@@ -18,8 +18,11 @@ class SMTPMailingQueueTools extends SMTPMailingQueueAdmin {
 	 */
 	private $prefill = false;
 
-	public function __construct() {
+	private $smtpMailingQueue;
+
+	public function __construct($smtpMailingQueue) {
 		parent::__construct();
+		$this->smtpMailingQueue = $smtpMailingQueue;
 		$this->init();
 	}
 
@@ -251,14 +254,12 @@ class SMTPMailingQueueTools extends SMTPMailingQueueAdmin {
 	 * Processes starting queue processing form
 	 */
 	public function startProcessQueue() {
-		global $smtpMailingQueue;
-
 		if(!check_admin_referer('smq-process_queue', 'smq-process_queue_nonce')) {
 			$this->showNotice(__("Looks like you're not allowed to do this", 'smtp-mailing-queue'));
 			return;
 		}
 
-		$smtpMailingQueue->callProcessQueue();
+		$this->smtpMailingQueue->callProcessQueue();
 
 		$this->showNotice(__('Emails sent', 'smtp-mailing-queue'), 'updated');
 	}
@@ -269,8 +270,7 @@ class SMTPMailingQueueTools extends SMTPMailingQueueAdmin {
 	 * @param bool $invalid
 	 */
 	private function createListQueue($invalid = false) {
-		global $smtpMailingQueue;
-		$data = $smtpMailingQueue->loadDataFromFiles(true, $invalid);
+		$data = $this->smtpMailingQueue->loadDataFromFiles(true, $invalid);
 		if(!$data) {
 			echo '<p>' . __('No mails in queue', 'smtp-mailing-queue') . '</p>';
 			return;

--- a/classes/SMTPMailingQueueUpdate.php
+++ b/classes/SMTPMailingQueueUpdate.php
@@ -7,14 +7,16 @@ class SMTPMailingQueueUpdate {
 	 */
 	protected $smtpMailingQueue;
 
-	/**
+    public function __construct($smtpMailingQueue)
+    {
+        $this->smtpMailingQueue = $smtpMailingQueue;
+    }
+
+    /**
 	 * Handles plugin updates if necessary.
 	 */
 	public function update() {
 		require_once ABSPATH . WPINC . '/class-phpmailer.php';
-
-		global $smtpMailingQueue;
-		$this->smtpMailingQueue = $smtpMailingQueue;
 
 		$installedVersion = get_option( "smq_version" );
 

--- a/smtp-mailing-queue.php
+++ b/smtp-mailing-queue.php
@@ -37,10 +37,10 @@ if(is_admin() && version_compare(PHP_VERSION, '5.4', '<')) {
 	require_once('classes/SMTPMailingQueueTools.php');
 
 	$smtpMailingQueue = new SMTPMailingQueue(__FILE__);
-	$smtpMailingQueueUpdate = new SMTPMailingQueueUpdate(__FILE__);
-	new SMTPMailingQueueOptions();
-	new SMTPMailingQueueAdvancedOptions();
-	new SMTPMailingQueueTools();
+	$smtpMailingQueueUpdate = new SMTPMailingQueueUpdate($smtpMailingQueue);
+	new SMTPMailingQueueOptions($smtpMailingQueue);
+	new SMTPMailingQueueAdvancedOptions($smtpMailingQueue);
+	new SMTPMailingQueueTools($smtpMailingQueue);
 
 	// overwriting wp_mail() to store mailing data instead of sending immediately
 	if (!function_exists('wp_mail') && !isset($_GET['smqProcessQueue'])) {


### PR DESCRIPTION
1. remove global dependency to SMTPMailingQueue from other classes, but inject SMTPMailingQueue to other classes when new instances

2. add changes from https://github.com/hildende/smtp-mailing-queue/pull/3

I remove global smtp queue instance because when I include wordpress from a controller in another project, the global variable can't be reached.